### PR TITLE
Implement load_mnist function to load MNIST dataset from CSV

### DIFF
--- a/src/fun_utils.py
+++ b/src/fun_utils.py
@@ -32,3 +32,22 @@ def split_data(x, y, tr_fraction=0.5):
 
     """
     pass
+
+def load_mnist(csv_filename: str):
+    """
+    Load the MNIST dataset from a csv file
+
+    Parameters
+    ----------
+    csv_filename : string
+        Filename to be loaded.
+
+    Returns
+    -------
+    X : ndarray
+        the data matrix.
+
+    y : ndarray
+        the labels of each sample.
+    """
+    return load_data(csv_filename)


### PR DESCRIPTION
This pull request adds a new utility function to help load the MNIST dataset from a CSV file. The main change is the introduction of the `load_mnist` function, which wraps the existing `load_data` function for improved clarity and reusability.

**New utility function:**

* Added the `load_mnist` function to `src/fun_utils.py` for loading the MNIST dataset from a CSV file, providing clear documentation and returning the data matrix and labels.